### PR TITLE
Autoloader will only load SDK specific classes.

### DIFF
--- a/Source/AutoLoader.php
+++ b/Source/AutoLoader.php
@@ -3,6 +3,11 @@
 define('DOCUMENT_ROOT', dirname(__FILE__) . DIRECTORY_SEPARATOR);
 
 spl_autoload_register (function ($class) {
+  //I will only try to load my classes
+  if ( strpos($class, "Epignosis\\eFrontPro\\Sdk\\")!==0 ) {
+    return;
+  }
+
   $file = str_replace (
     '\\', DIRECTORY_SEPARATOR, DOCUMENT_ROOT . $class . '.php'
   );


### PR DESCRIPTION
This will allow usage with other autoloaders and prevent RuntimeExceptions for classes outside the SDK namespace.
